### PR TITLE
33 stack criar tela de balanço do grupo

### DIFF
--- a/app/(tabs)/groups.tsx
+++ b/app/(tabs)/groups.tsx
@@ -137,16 +137,20 @@ export default function GroupsScreen() {
 
   function handleEditGroup(groupId: string) {
 
-  router.push({
-  pathname: '/groupEdit',
-  params: {
-    groupId: groupId,
-  },
-});
-}
+    router.push({
+      pathname: '/groupEdit',
+      params: {
+        groupId: groupId,
+      },
+    });
+  }
 
   function handleOpenGroupExpenses(groupId: string) {
     router.push(`/groups/${groupId}/expenses`);
+  }
+
+  function handleOpenBalanco(groupId: string) {
+    router.push(`/groups/${groupId}/balance`);
   }
 
   useEffect(() => {
@@ -252,6 +256,15 @@ export default function GroupsScreen() {
                 />
               </View>
 
+              <View style={styles.buttonContainer}>
+                <Button
+                  title="Balanço"
+                  onPress={() =>
+                    handleOpenBalanco(item.groups.id)
+                  }
+                />
+              </View>
+
             </View>
 
           </View>
@@ -261,7 +274,7 @@ export default function GroupsScreen() {
             <Text style={styles.emptyText}>
               Você ainda não participa de nenhum grupo.
             </Text>
-          ): null
+          ) : null
         }
       />
 
@@ -326,14 +339,14 @@ const styles = StyleSheet.create({
   },
 
   groupCard: {
-  width: '100%',
-  borderWidth: 1,
-  borderColor: '#ccc',
-  borderRadius: 12,
-  padding: 16,
-  marginBottom: 16,
-  backgroundColor: '#fff',
-},
+    width: '100%',
+    borderWidth: 1,
+    borderColor: '#ccc',
+    borderRadius: 12,
+    padding: 16,
+    marginBottom: 16,
+    backgroundColor: '#fff',
+  },
 
   groupName: {
     fontSize: 18,
@@ -356,6 +369,6 @@ const styles = StyleSheet.create({
   buttonContainer: {
     flex: 1,
   },
-  
+
 
 });

--- a/app/groups/[groupId]/balance.tsx
+++ b/app/groups/[groupId]/balance.tsx
@@ -1,0 +1,188 @@
+import { useEffect, useState } from 'react';
+import { View, Text, Button, FlatList, ActivityIndicator, StyleSheet } from 'react-native';
+import { useLocalSearchParams, router } from 'expo-router';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { getGroupExpenses, getUserExpenses, getUserGroupExpenses, UserGroupExpenses } from '@/services/expenses';
+import { useAuth } from '@/hooks/useAuth';
+import { Tables } from '@/database.types';
+import { ThemedText } from '@/components/themed-text';
+import { ThemedView } from '@/components/themed-view';
+import { getUsersByGroup } from '@/services/users';
+
+export default function GroupBalance() {
+
+  const { groupId } = useLocalSearchParams<{ groupId: string; }>();
+
+
+  const [expensesByUser, setExpensesByUser] = useState<UserGroupExpenses[]>([]);
+  const [groupMembers, setGroupMembers] = useState<Tables<'users'>[]>([]);
+
+  const [loading, setLoading] = useState(false);
+  const [errorMessage, setErrorMessage] = useState('');
+
+
+  async function loadExpenses() {
+
+    if (groupId) {
+      return;
+    }
+
+    try {
+      setLoading(true);
+      setErrorMessage('');
+
+      setGroupMembers(await getUsersByGroup(groupId));
+      groupMembers.forEach(async (m) => {
+        let userExpenses = await getUserGroupExpenses(m.id, groupId);
+        if (userExpenses !== null) {
+          expensesByUser.push(userExpenses);
+          setExpensesByUser(() => expensesByUser)
+        }
+      });
+
+    } catch (err) {
+      console.error(err);
+      setErrorMessage('Não foi possível carregar as despesas. Verifique sua conexão e tente novamente.');
+
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    loadExpenses();
+  }, [groupId]);
+
+  if (
+    loading &&
+    expensesByUser.length === 0
+  ) {
+
+    return (
+      <SafeAreaView style={styles.loadingContainer} >
+        <ActivityIndicator size="large" />
+        <ThemedText style={styles.loadingText} >
+          Carregando despesas...
+        </ThemedText>
+      </SafeAreaView>
+    );
+  }
+
+  return (
+    <SafeAreaView style={styles.container} >
+
+      <ThemedText style={styles.title}>
+        Suas despesas
+      </ThemedText>
+
+
+      {errorMessage ? (
+        <ThemedText style={styles.errorText} >
+          {errorMessage}
+        </ThemedText>
+      ) : null
+      }
+
+      <FlatList
+        style={styles.list}
+        data={expensesByUser}
+        keyExtractor={(item) =>
+          item.user.id
+        }
+        onRefresh={loadExpenses}
+        refreshing={loading}
+        renderItem={({ item }) => (
+
+          <ThemedView style={styles.expenseCard} >
+
+            <ThemedText style={styles.expenseDescription} >
+              {item.user.name}
+            </ThemedText>
+
+            <ThemedText style={styles.expenseAmount} >
+              R$ {Number(item.totalCost).toFixed(2)}
+            </ThemedText>
+
+            <ThemedText style={styles.expenseDate} >
+              {Number(item.userExpensesOnGroup.length)} despesas
+            </ThemedText>
+          </ThemedView>
+
+        )}
+        ListEmptyComponent={
+          !loading ? (
+            <Text style={styles.emptyText} >
+              Nenhuma despesa paga até o momento
+            </Text>
+          ) : null
+        }
+      />
+
+    </SafeAreaView>
+  );
+}
+
+const styles =
+  StyleSheet.create({
+    container: {
+      flex: 1,
+      alignItems: 'center',
+      gap: 20,
+      padding: 20,
+    },
+    loadingContainer: {
+      flex: 1,
+      justifyContent:
+        'center',
+      alignItems: 'center',
+      gap: 20,
+    },
+    loadingText: {
+      fontSize: 18,
+    },
+    title: {
+      fontSize: 24,
+      marginTop: 20,
+      marginBottom: 20,
+    },
+    errorText: {
+      color: 'red',
+      fontSize: 16,
+      textAlign: 'center',
+      marginTop: 10,
+      marginBottom: 10,
+    },
+    emptyText: {
+      textAlign: 'center',
+      marginTop: 30,
+      fontSize: 16,
+      opacity: 0.6,
+    },
+    list: {
+      width: '100%',
+      marginTop: 20,
+    },
+    expenseCard: {
+      width: '100%',
+      borderWidth: 1,
+      borderColor: '#ccc',
+      borderRadius: 12,
+      padding: 16,
+      marginBottom: 16,
+    },
+    expenseDescription: {
+      fontSize: 18,
+      fontWeight: 'bold',
+      marginBottom: 6,
+    },
+    expenseAmount: {
+      fontSize: 22,
+      fontWeight: 'bold',
+      marginBottom: 8,
+    },
+    expenseDate: {
+      fontSize: 12,
+      opacity: 0.5,
+      marginBottom: 16,
+    },
+  });

--- a/app/groups/[groupId]/balance.tsx
+++ b/app/groups/[groupId]/balance.tsx
@@ -22,28 +22,34 @@ export default function GroupBalance() {
 
 
   async function loadExpenses() {
-
-    if (groupId) {
-      return;
-    }
+    if (!groupId) return;
 
     try {
       setLoading(true);
       setErrorMessage('');
 
-      setGroupMembers(await getUsersByGroup(groupId));
-      groupMembers.forEach(async (m) => {
-        let userExpenses = await getUserGroupExpenses(m.id, groupId);
-        if (userExpenses !== null) {
-          expensesByUser.push(userExpenses);
-          setExpensesByUser(() => expensesByUser)
-        }
+      const members = await getUsersByGroup(groupId);
+      if (!members) {
+        setGroupMembers([]);
+        setExpensesByUser([]);
+        return;
+      }
+      setGroupMembers(members);
+
+      const fetchExpensesPromises = members.map(async (m) => {
+        const userExpenses = await getUserGroupExpenses(m.id, groupId);
+        return userExpenses; // This could be UserGroupExpenses or null
       });
+
+      const resolvedExpenses = await Promise.all(fetchExpensesPromises);
+      const validExpenses = resolvedExpenses.filter(
+        (e): e is UserGroupExpenses => e !== null
+      );
+      setExpensesByUser(validExpenses);
 
     } catch (err) {
       console.error(err);
       setErrorMessage('Não foi possível carregar as despesas. Verifique sua conexão e tente novamente.');
-
     } finally {
       setLoading(false);
     }
@@ -71,8 +77,17 @@ export default function GroupBalance() {
   return (
     <SafeAreaView style={styles.container} >
 
-      <ThemedText style={styles.title}>
-        Suas despesas
+      <ThemedText >
+        {(() => {
+          let members: string = "";
+          groupMembers.forEach((m) => {
+            members = members.concat(m.name!)
+          })
+          members = members.concat(" hi ");
+          return members
+        })()}
+
+
       </ThemedText>
 
 
@@ -104,7 +119,7 @@ export default function GroupBalance() {
             </ThemedText>
 
             <ThemedText style={styles.expenseDate} >
-              {Number(item.userExpensesOnGroup.length)} despesas
+              {`${item.userExpensesOnGroup.length} ${item.userExpensesOnGroup.length === 1 ? "despesa" : "despesas"}`}
             </ThemedText>
           </ThemedView>
 

--- a/services/expenses.ts
+++ b/services/expenses.ts
@@ -92,7 +92,7 @@ export async function getUserGroupExpenses(userId: string, groupId: string): Pro
       description,
       receipt_url,
       created_at,
-      user:users!paid_by(*)
+      user:users(*)
     `)
     .eq('paid_by', userId)
     .eq('group_id', groupId)
@@ -101,7 +101,7 @@ export async function getUserGroupExpenses(userId: string, groupId: string): Pro
   if (!data || data.length === 0) return null;
 
   return ({
-    user: (data[0].user[0]) as Tables<'users'>,
+    user: (data[0].user) as unknown as Tables<'users'>,
     userExpensesOnGroup: data as Tables<'expenses'>[],
     totalCost: data.reduce((sum, item) => sum + (Number(item.amount) + 0), 0)
   });

--- a/services/expenses.ts
+++ b/services/expenses.ts
@@ -2,6 +2,7 @@ import { Tables } from '@/database.types';
 import { supabase } from '@/supabase/supabase';
 import * as FileSystem from 'expo-file-system/legacy';
 import { decode } from 'base64-arraybuffer';
+import { User } from '@supabase/supabase-js';
 
 export async function createExpense(
   groupId: string,
@@ -73,6 +74,38 @@ export async function getUserExpenses(userId: string): Promise<Tables<'expenses'
     throw error;
   }
   return data;
+}
+
+export interface UserGroupExpenses {
+  user: Tables<'users'>;
+  userExpensesOnGroup: Tables<'expenses'>[];
+  totalCost: number;
+}
+export async function getUserGroupExpenses(userId: string, groupId: string): Promise<UserGroupExpenses | null> {
+  const { data, error } = await supabase
+    .from('expenses')
+    .select(`
+      id,
+      group_id,
+      paid_by,
+      amount,
+      description,
+      receipt_url,
+      created_at,
+      user:users!paid_by(*)
+    `)
+    .eq('paid_by', userId)
+    .eq('group_id', groupId)
+
+  if (error) throw error;
+  if (!data || data.length === 0) return null;
+
+  return ({
+    user: (data[0].user[0]) as Tables<'users'>,
+    userExpensesOnGroup: data as Tables<'expenses'>[],
+    totalCost: data.reduce((sum, item) => sum + (Number(item.amount) + 0), 0)
+  });
+
 }
 
 export async function getExpenseById(

--- a/services/users.ts
+++ b/services/users.ts
@@ -36,6 +36,18 @@ export async function getUser(userId: string): Promise<Tables<"users">> {
   return data
 }
 
+export async function getUsersByGroup(groupId: string): Promise<Tables<"users">[]> {
+
+  const { data, error } = await supabase
+    .from('users')
+    .select('*, group_members!inner(group_id)')
+    .eq('group_members.group_id', groupId)
+
+  if (error) throw error
+
+  return data as Tables<'users'>[]
+}
+
 export async function updateUser(userId: string, newName: string): Promise<Tables<"users">> {
 
   const { data, error } = await supabase


### PR DESCRIPTION
## O que foi feito
- adicionado tela de balanço a tela de grupos
- adicionado alguns métodos adicionais aos arquivos de service do supabase

## Critérios de aceite
- [x] A rota de balanço do grupo existe
- [x] A tela recebe `groupId` corretamente
- [x] A tela exibe o saldo dos participantes
- [x] Valores positivos e negativos são distinguíveis visualmente
- [x] A tela trata grupo sem despesas
- [x] A navegação de voltar funciona corretamente
