### PR TITLE
fixes: regras RLS e valores numericos

### DIFF
--- a/app/groups/[groupId]/expenses/new.tsx
+++ b/app/groups/[groupId]/expenses/new.tsx
@@ -84,12 +84,14 @@ export default function NewExpenseScreen() {
       return;
     }
 
+    const parsedAmount = Number(amount.replace(',', '.').trim());
+
     if (!description.trim() || !amount.trim()) {
       setErrorMessage('Digite uma descrição e valor para a despesa.');
       return;
     }
 
-    if (Number(amount) <= 0) {
+    if (!Number.isFinite(parsedAmount) || parsedAmount <= 0) {
       setErrorMessage('O valor deve ser maior que zero.');
       return;
     }
@@ -108,7 +110,7 @@ export default function NewExpenseScreen() {
         String(groupId),
         session.user.id,
         description.trim(),
-        Number(amount),
+        parsedAmount,
         uploadedReceiptUrl,
       );
 

--- a/supabase/rls.sql
+++ b/supabase/rls.sql
@@ -60,13 +60,24 @@ alter table public.expenses enable row level security;
 -- 3) USERS policies
 -- =====================================================
 
--- Usuario autenticado ve e altera somente o proprio perfil.
+-- Usuario autenticado ve o proprio perfil e perfis de usuarios do mesmo grupo.
 -- Insercao so pode acontecer com id = auth.uid().
 drop policy if exists users_select_own on public.users;
 create policy users_select_own
 on public.users
 for select
-using (id = auth.uid());
+to authenticated
+using (
+  id = auth.uid()
+  or exists (
+    select 1
+    from public.group_members gm_me
+    join public.group_members gm_other
+      on gm_other.group_id = gm_me.group_id
+    where gm_me.user_id = auth.uid()
+      and gm_other.user_id = users.id
+  )
+);
 
 drop policy if exists users_insert_own on public.users;
 create policy users_insert_own


### PR DESCRIPTION
- sistema nao aceitava numero com decimais ao registrar despesa
- sistema nao mostrava o usuário que criou a despesa, se não fosse o próprio usuário logado, por conta das regras de RLS